### PR TITLE
Bgd 5953 reapply out changes to js v2142

### DIFF
--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -36,6 +36,7 @@ from .gateway_client import GatewayClient, gateway_request
 if TYPE_CHECKING:
     from logging import Logger
 
+_local_kernels: dict[str, ServerKernelManager] = {}
 
 class GatewayMappingKernelManager(AsyncMappingKernelManager):
     """Kernel manager that supports remote kernels hosted by Jupyter Kernel or Enterprise Gateway."""
@@ -78,20 +79,38 @@ class GatewayMappingKernelManager(AsyncMappingKernelManager):
             The API path (unicode, '/' delimited) for the cwd.
             Will be transformed to an OS path relative to root_dir.
         """
-        self.log.info(f"Request start kernel: kernel_id={kernel_id}, path='{path}'")
+        kernel_name = kwargs.get("kernel_name")
+        if kernel_name == 'python3' or kernel_name.startswith('sc-'):
+            kwargs["kernel_name"] = "python3"
+            kwargs["local"] = True
+            env = kwargs["env"]
+            if kernel_name.startswith('sc-'):
+                app = kernel_name
+                startup_file = f"/tmp/{app}.py"
+                startup_content = f"""from pyspark.sql import SparkSession
+spark = SparkSession.builder.appName('{kernel_name}').remote('sc://{app}-driver-svc.spark-apps.svc.cluster.local').getOrCreate()
+"""
+                env["PYTHONSTARTUP"] = startup_file
+                with open(startup_file, "w") as f:
+                    f.write(startup_content)
+            kernel_id = await super().start_kernel(kernel_id=kernel_id, path=path, **kwargs)
+            _local_kernels[kernel_id] = self._kernels[kernel_id]
+            return kernel_id
+        else:
+            self.log.info(f"Request start kernel: kernel_id={kernel_id}, path='{path}'")
+            
+            if kernel_id is None and path is not None:
+                kwargs["cwd"] = self.cwd_for_path(path)
+            
+            km = self.kernel_manager_factory(parent=self, log=self.log)
+            await km.start_kernel(kernel_id=kernel_id, **kwargs)
+            kernel_id = km.kernel_id
+            self._kernels[kernel_id] = km
+            # Initialize culling if not already
+            if not self._initialized_culler:
+                self.initialize_culler()
 
-        if kernel_id is None and path is not None:
-            kwargs["cwd"] = self.cwd_for_path(path)
-
-        km = self.kernel_manager_factory(parent=self, log=self.log)
-        await km.start_kernel(kernel_id=kernel_id, **kwargs)
-        kernel_id = km.kernel_id
-        self._kernels[kernel_id] = km
-        # Initialize culling if not already
-        if not self._initialized_culler:
-            self.initialize_culler()
-
-        return kernel_id
+            return kernel_id
 
     async def kernel_model(self, kernel_id):
         """Return a dictionary of kernel information described in the
@@ -102,11 +121,17 @@ class GatewayMappingKernelManager(AsyncMappingKernelManager):
         kernel_id : uuid
             The uuid of the kernel.
         """
-        model = None
-        km = self.get_kernel(str(kernel_id))
-        if km:  # type:ignore[truthy-bool]
-            model = km.kernel  # type:ignore[attr-defined]
-        return model
+        if kernel_id in _local_kernels:
+            str_kernel_id = str(kernel_id)
+            model = super().kernel_model(kernel_id)
+            _local_kernels[str_kernel_id] = model
+            return model
+        else:
+            model = None
+            km = self.get_kernel(str(kernel_id))
+            if km:  # type:ignore[truthy-bool]
+                model = km.kernel  # type:ignore[attr-defined]
+            return model
 
     async def list_kernels(self, **kwargs):
         """Get a list of running kernels from the Gateway server.
@@ -437,19 +462,22 @@ class GatewayKernelManager(ServerKernelManager):
             model is fetched from the Gateway server.
         """
         if model is None:
-            self.log.debug("Request kernel at: %s" % self.kernel_url)
-            try:
-                response = await gateway_request(self.kernel_url, method="GET")
-
-            except web.HTTPError as error:
-                if error.status_code == 404:
-                    self.log.warning("Kernel not found at: %s" % self.kernel_url)
-                    model = None
-                else:
-                    raise
+            if self.kernel_id in _local_kernels:
+                model = _local_kernels[self.kernel_id]
             else:
-                model = json_decode(response.body)
-            self.log.debug("Kernel retrieved: %s" % model)
+                self.log.debug("Request kernel at: %s" % self.kernel_url)
+                try:
+                    response = await gateway_request(self.kernel_url, method="GET")
+                
+                except web.HTTPError as error:
+                    if error.status_code == 404:
+                        self.log.warning("Kernel not found at: %s" % self.kernel_url)
+                        model = None
+                    else:
+                        raise
+                else:
+                    model = json_decode(response.body)
+                self.log.debug("Kernel retrieved: %s" % model)
 
         if model:  # Update activity markers
             self.last_activity = datetime.datetime.strptime(
@@ -483,6 +511,13 @@ class GatewayKernelManager(ServerKernelManager):
              and launching the kernel (e.g. Popen kwargs).
         """
         kernel_id = kwargs.get("kernel_id")
+
+        if "local" in kwargs:
+            kwargs.pop("local")
+            self.kernel_id = kernel_id
+            self.kernel_url = url_path_join(self.kernels_url, url_escape(str(self.kernel_id)))
+            self.kernel = await self.refresh_model()
+            await super().start_kernel(**kwargs)
 
         if kernel_id is None:
             kernel_name = kwargs.get("kernel_name", "python3")

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -251,6 +251,7 @@ class ServerWebApplication(web.Application):
         authorizer=None,
         identity_provider=None,
         kernel_websocket_connection_class=None,
+        local_kernel_websocket_connection_class=None,
         websocket_ping_interval=None,
         websocket_ping_timeout=None,
     ):
@@ -290,6 +291,7 @@ class ServerWebApplication(web.Application):
             authorizer=authorizer,
             identity_provider=identity_provider,
             kernel_websocket_connection_class=kernel_websocket_connection_class,
+            local_kernel_websocket_connection_class=local_kernel_websocket_connection_class,
             websocket_ping_interval=websocket_ping_interval,
             websocket_ping_timeout=websocket_ping_timeout,
         )
@@ -357,6 +359,7 @@ class ServerWebApplication(web.Application):
         authorizer=None,
         identity_provider=None,
         kernel_websocket_connection_class=None,
+        local_kernel_websocket_connection_class=None,
         websocket_ping_interval=None,
         websocket_ping_timeout=None,
     ):
@@ -442,6 +445,7 @@ class ServerWebApplication(web.Application):
             "identity_provider": identity_provider,
             "event_logger": event_logger,
             "kernel_websocket_connection_class": kernel_websocket_connection_class,
+            "local_kernel_websocket_connection_class": local_kernel_websocket_connection_class,
             "websocket_ping_interval": websocket_ping_interval,
             "websocket_ping_timeout": websocket_ping_timeout,
             # handlers
@@ -1630,12 +1634,24 @@ class ServerApp(JupyterApp):
         help=_i18n("The kernel websocket connection class to use."),
     )
 
+    local_kernel_websocket_connection_class = Type(
+        klass=BaseKernelWebsocketConnection,
+        config=True,
+        help=_i18n("The local kernel websocket connection class to use."),
+    )
+
     @default("kernel_websocket_connection_class")
     def _default_kernel_websocket_connection_class(
         self,
     ) -> t.Union[str, type[ZMQChannelsWebsocketConnection]]:
         if self.gateway_config.gateway_enabled:
             return "jupyter_server.gateway.connections.GatewayWebSocketConnection"
+        return ZMQChannelsWebsocketConnection
+
+    @default("local_kernel_websocket_connection_class")
+    def _default_local_kernel_websocket_connection_class(
+        self,
+    ) -> t.Union[str, type[ZMQChannelsWebsocketConnection]]:
         return ZMQChannelsWebsocketConnection
 
     websocket_ping_interval = Integer(
@@ -2252,6 +2268,7 @@ class ServerApp(JupyterApp):
             authorizer=self.authorizer,
             identity_provider=self.identity_provider,
             kernel_websocket_connection_class=self.kernel_websocket_connection_class,
+            local_kernel_websocket_connection_class=self.local_kernel_websocket_connection_class,
             websocket_ping_interval=self.websocket_ping_interval,
             websocket_ping_timeout=self.websocket_ping_timeout,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "anyio>=3.1.0",
     "argon2-cffi>=21.1",


### PR DESCRIPTION
The original pseudo waiting kernel changes got lost when upgrading jupyter server from 2.12.5 to 2.14.2. Reapplying the code

# Jira Ticket

[BGD-5953](https://spotinst.atlassian.net/browse/BGD-5953)

# Checklist:
- [x] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [x] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have validated all the requirements in the Jira task were answered
- [x] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 


[BGD-5953]: https://spotinst.atlassian.net/browse/BGD-5953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ